### PR TITLE
Add code command for windows

### DIFF
--- a/code-open-server/src/main.rs
+++ b/code-open-server/src/main.rs
@@ -20,7 +20,13 @@ fn get_table_file_path() -> String {
 }
 
 fn open_vscode_in_other_process(code_open_info: CodeOpenInfo) {
-    Command::new("code")
+    let mut code_command = if cfg!(target_os = "windows") {
+        Command::new("code.cmd")
+    } else {
+        Command::new("code")
+    };
+
+    code_command
         .arg("--remote")
         .arg(format!("ssh-remote+{}", code_open_info.remote_host_name))
         .arg(code_open_info.remote_dir_full_path)
@@ -75,7 +81,10 @@ fn resolve_host_name_to_local_configured_name(
 
 fn server_start(code_open_config: &CodeOpenConfig, table: &HashMap<String, String>) {
     let listener = TcpListener::bind((code_open_config.ip.clone(), code_open_config.port)).unwrap();
-    println!("Server is started! - {}:{}", code_open_config.ip, code_open_config.port);
+    println!(
+        "Server is started! - {}:{}",
+        code_open_config.ip, code_open_config.port
+    );
 
     for stream in listener.incoming() {
         println!("{:?}", stream);


### PR DESCRIPTION
# 背景

- Windows で VSCode を呼び出すためには `code` ではなく `code.cmd` を呼び出すか、`cmd` 上のコマンドとして `code` を呼び出す必要がある

# 変更点

- 実行環境が Windows の場合は `code.cmd` を呼び出すように変更